### PR TITLE
ci(release): 更新发布工作流以处理重复标签和文件重命名

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,10 @@ jobs:
         id: commits
         run: |
           PREV_TAG=$(git tag --list "v[0-9]*" --sort=-v:refname | grep -Ev "rc|beta|alpha" | head -n 1)
+          CURRENT_TAG=${{ github.ref_name }}
+          if [ "$PREV_TAG" = "$CURRENT_TAG" ]; then
+            PREV_TAG=$(git tag --list "v[0-9]*" --sort=-v:refname | grep -Ev "rc|beta|alpha" | head -n 2 | tail -n 1)
+          fi
           echo "prev_tag=$PREV_TAG" >> $GITHUB_OUTPUT
           
           # Correctly handle multi-line output
@@ -25,6 +29,11 @@ jobs:
           echo "commits<<EOF" >> $GITHUB_OUTPUT
           echo "$commits" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Rename files
+        run: |
+          find Windows/ -type f -name '*.ps1' -exec bash -c 'mv "$0" "$(dirname "$0")/$(basename "$0" | sed "s/按需下载万象方案-词库-模型/rime-wanxiang-update-windows/")"' {} \;
+          find Windows/ -type f -name '*.py' -exec bash -c 'mv "$0" "$(dirname "$0")/$(basename "$0" | sed "s/按需下载万象方案-词库-模型/rime-wanxiang-update-windows/")"' {} \;
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
@@ -36,6 +45,6 @@ jobs:
             ${{ steps.commits.outputs.commits }}
           prerelease: ${{ contains(github.ref_name, '-rc') }}
           files: |
-            Windows/PowerShell/按需下载万象方案-词库-模型.ps1
-            Windows/PowerShell/按需下载万象方案-词库-模型-utf-8.ps1
-            Windows/Python/按需下载万象方案-词库-模型.py
+            Windows/PowerShell/rime-wanxiang-update-windows.ps1
+            Windows/PowerShell/rime-wanxiang-update-windows-utf-8.ps1
+            Windows/Python/rime-wanxiang-update-windows.py


### PR DESCRIPTION
更新了发布工作流，添加了处理重复标签的逻辑，确保在标签重复时能正确获取上一个标签。同时，添加了文件重命名步骤，将Windows目录下的文件名称统一更新为新的命名规范，以便更好地管理和识别文件。