### PR TITLE
Update 解压函数修改为调用7zip

### DIFF
--- a/Windows/PowerShell/按需下载万象方案-词库-模型-utf-8.ps1
+++ b/Windows/PowerShell/按需下载万象方案-词库-模型-utf-8.ps1
@@ -779,15 +779,49 @@ function Expand-ZipFile {
         [string]$zipFilePath,
         [string]$destinationPath
     )
-
+ 
     try {
         Write-Host "正在解压文件: $zipFilePath" -ForegroundColor Green
         Write-Host "解压到: $destinationPath" -ForegroundColor Green
-        Expand-Archive -Path $zipFilePath -DestinationPath $destinationPath -Force
+ 
+        # --- 获取 7z.exe 路径 ---
+        $weaselRootDir = Get-WeaselInstallDir
+        if (-not $weaselRootDir) {
+            Throw "无法获取小狼毫输入法安装目录，因此无法定位 7z.exe 进行解压。"
+        }
+        $sevenZipPath = Join-Path $weaselRootDir "7z.exe"
+ 
+        # 检查 7z.exe 是否存在
+        if (-not (Test-Path $sevenZipPath -PathType Leaf)) {
+            Throw "找不到 7z.exe。预期路径: '$sevenZipPath'。请确认小狼毫输入法安装正常且包含 7z.exe"
+        }
+        Write-Host "已找到 7z.exe：$sevenZipPath" -ForegroundColor DarkCyan
+ 
+        # --- 确保目标目录存在 ---
+        if (-not (Test-Path $destinationPath)) {
+            try {
+                New-Item -Path $destinationPath -ItemType Directory -Force | Out-Null
+                Write-Host "已创建目标目录: $destinationPath" -ForegroundColor Yellow
+            }
+            catch {
+                Throw "创建目标目录 '$destinationPath' 失败: $($_.Exception.Message)。"
+            }
+        }
+ 
+        # --- 调用 7z.exe 进行解压 ---
+        $arguments = "x `"$zipFilePath`" -o`"$destinationPath`" -y"
+        Write-Host "正在调用 7-Zip 进行解压..." -ForegroundColor DarkGreen
+ 
+        $process = Start-Process -FilePath $sevenZipPath -ArgumentList $arguments -Wait -PassThru -NoNewWindow
+      
+        if ($process.ExitCode -ne 0) {
+            Throw "7-Zip 解压失败，退出代码: $($process.ExitCode)。"
+        }
+      
         Write-Host "解压完成" -ForegroundColor Green
     }
     catch {
-        Write-Host "解压失败: $_" -ForegroundColor Red
+        Write-Host "解压失败: $($_.Exception.Message)" -ForegroundColor Red
         Remove-Item -Path $zipFilePath -Force -ErrorAction SilentlyContinue
         Exit-Tip 1
     }


### PR DESCRIPTION
解决从CNB下载的方案压缩包解压失败的问题[124](https://github.com/expoli/rime-wanxiang-update-tools/issues/124)。

酌情考虑是否merge吧，win10用户可能没那么多了，win11默认带的PowerShell7不会有这个错误。